### PR TITLE
Use node:8.15.1-stretch-slim instead of alpine

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/.data/
+/node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:10.15.3-alpine
+FROM node:8.15.1-stretch-slim
 
 # https://circleci.com/gh/zeit/now-cli/tree/now-dev
-RUN wget -O /usr/local/bin/now-alpine 'https://latest-now-cli.now.sh/download/17743/now-alpine' \
-  && chmod +x /usr/local/bin/now-alpine
+RUN wget -O /usr/local/bin/now-linux 'https://latest-now-cli.now.sh/download/17743/now-linux' \
+  && chmod +x /usr/local/bin/now-linux

--- a/dev.sh
+++ b/dev.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec now-alpine --debug --token xxx dev .
+exec now-linux --debug --token xxx dev .

--- a/docker.sh
+++ b/docker.sh
@@ -11,4 +11,4 @@ exec docker run --rm -it --name $_name \
   -v "${PWD}:/app" -w /app \
   -v "${PWD}/.data/root/.cache:/root/.cache" \
   -v "${PWD}/.data/root/.npm:/root/.npm" \
-  $_name sh
+  $_name bash


### PR DESCRIPTION
This is needed because the co.zeit.fun node runtime does not support Alpine.